### PR TITLE
[BUGFIX] Avoid displaying env in title if banner is not shown

### DIFF
--- a/Classes/Renderer.php
+++ b/Classes/Renderer.php
@@ -222,11 +222,10 @@ class Renderer
      */
     public function contentPostProcOutputHook(array &$params)
     {
-        $feobj = &$params['pObj'];
 
         // @TODO eId = ??
-
         if ($this->isFrontendBannerShown()) {
+            $feobj = &$params['pObj'];
             $outputArray = array();
             preg_match('/<body[^<]*>/', $feobj->content, $outputArray);
 
@@ -235,16 +234,16 @@ class Renderer
             $bodyTag = array_shift($outputArray);
 
             $feobj->content = str_replace($bodyTag, $bodyTag . $this->renderFrontendBanner(), $feobj->content);
+
+            $outputArray = array();
+            preg_match('/<title[^<]*>/', $feobj->content, $outputArray);
+
+            // We expect the first occurence of <title> to be the correct one
+            // there should be only one anyway
+            $titleTag = array_shift($outputArray);
+
+            $feobj->content = str_replace($titleTag, $titleTag . $this->getBannerText() . ' - ', $feobj->content);
         }
-
-        $outputArray = array();
-        preg_match('/<title[^<]*>/', $feobj->content, $outputArray);
-
-        // We expect the first occurence of <title> to be the correct one
-        // there should be only one anyway
-        $titleTag = array_shift($outputArray);
-
-        $feobj->content = str_replace($titleTag, $titleTag . $this->getBannerText() . ' - ', $feobj->content);
     }
 
     /**


### PR DESCRIPTION
Hi,

For production environment, we would be able to display banner in backend but not displaying it on FE.
At the moment, even if FE banner is disabled, "environment name" is displayed into <title> tag.

So I advice to disable all FE render it that case.

Regards,
